### PR TITLE
Fuzz harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,9 +70,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-core"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47ef9e96462d0b9fee9008c53c1f3d017b9498fcdef3ad8d728db98afef47955"
+checksum = "9c8316d83e590f4163b221b8180008f302bda5cf5451202855cdd323e588849c"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -83,9 +83,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-dyn-abi"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85132f2698b520fab3f54beed55a44389f7006a7b557a0261e1e69439dcc1572"
+checksum = "ef2364c782a245cf8725ea6dbfca5f530162702b5d685992ea03ce64529136cc"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -151,9 +151,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded610181f3dad5810f6ff12d1a99994cf9b42d2fcb7709029352398a5da5ae6"
+checksum = "b84c506bf264110fa7e90d9924f742f40ef53c6572ea56a0b0bd714a567ed389"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -211,9 +211,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd58d377699e6cfeab52c4a9d28bdc4ef37e2bd235ff2db525071fe37a2e9af5"
+checksum = "9fce5dbd6a4f118eecc4719eaa9c7ffc31c315e6c5ccde3642db927802312425"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -377,9 +377,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a1b42ac8f45e2f49f4bcdd72cbfde0bb148f5481d403774ffa546e48b83efc1"
+checksum = "9343289b4a7461ed8bab8618504c995c049c082b70c7332efd7b32125633dc05"
 dependencies = [
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
@@ -391,9 +391,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06318f1778e57f36333e850aa71bd1bb5e560c10279e236622faae0470c50412"
+checksum = "4222d70bec485ceccc5d8fd4f2909edd65b5d5e43d4aca0b5dcee65d519ae98f"
 dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
@@ -409,9 +409,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaebb9b0ad61a41345a22c9279975c0cdd231b97947b10d7aad1cf0a7181e4a5"
+checksum = "2e17f2677369571b976e51ea1430eb41c3690d344fef567b840bfc0b01b6f83a"
 dependencies = [
  "const-hex",
  "dunce",
@@ -424,9 +424,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12c71028bfbfec210e24106a542aad3def7caf1a70e2c05710e92a98481980d3"
+checksum = "aa64d80ae58ffaafdff9d5d84f58d03775f66c84433916dc9a64ed16af5755da"
 dependencies = [
  "serde",
  "winnow",
@@ -434,9 +434,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374d7fb042d68ddfe79ccb23359de3007f6d4d53c13f703b64fb0db422132111"
+checksum = "6520d427d4a8eb7aa803d852d7a52ceb0c519e784c292f64bb339e636918cf27"
 dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
@@ -693,6 +693,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -789,6 +798,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24b1f0365a6c6bb4020cd05806fd0d33c44d38046b8bd7f0e40814b9763cabfc"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver 1.0.23",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -879,6 +920,41 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1518,6 +1594,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1883,7 +1965,9 @@ dependencies = [
  "pade",
  "proc-macro2",
  "quote",
+ "serde",
  "syn 2.0.87",
+ "test-fuzz",
 ]
 
 [[package]]
@@ -2003,6 +2087,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2395,6 +2489,9 @@ name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "semver-parser"
@@ -2447,6 +2544,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2544,6 +2652,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2595,9 +2709,9 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edf42e81491fb8871b74df3d222c64ae8cbc1269ea509fa768a3ed3e1b0ac8cb"
+checksum = "f76fe0a3e1476bdaa0775b9aec5b869ed9520c2b2fedfe9c6df3618f8ea6290b"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -2648,6 +2762,58 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "test-fuzz"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab7a9bb33d134e863862ab9dad2ac7e022ac89707914627f498fe0f29248d9b"
+dependencies = [
+ "serde",
+ "test-fuzz-internal",
+ "test-fuzz-macro",
+ "test-fuzz-runtime",
+]
+
+[[package]]
+name = "test-fuzz-internal"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0bef5dd380747bd7b6e636a8032a24aa34fcecaf843e59fc97d299681922e86"
+dependencies = [
+ "bincode",
+ "cargo_metadata",
+ "serde",
+]
+
+[[package]]
+name = "test-fuzz-macro"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7e6b4c7391a38f0f026972ec2200bcfd1ec45533aa266fdae5858d011afc500"
+dependencies = [
+ "darling",
+ "heck",
+ "itertools 0.13.0",
+ "once_cell",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "test-fuzz-runtime"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9fbe6fb7481ec6d9bf64ae2c5d49cb1b40f8da624a91031482af7b08168c679"
+dependencies = [
+ "hex",
+ "num-traits",
+ "serde",
+ "sha1",
+ "test-fuzz-internal",
 ]
 
 [[package]]

--- a/pade-macro/Cargo.toml
+++ b/pade-macro/Cargo.toml
@@ -23,4 +23,6 @@ alloy = { workspace = true, features = [
 "signer-local",
   "sol-types",
 ] }
+test-fuzz = "6"
+serde = "1"
 pade.workspace = true

--- a/pade-macro/tests/complex.rs
+++ b/pade-macro/tests/complex.rs
@@ -123,6 +123,15 @@ fn regression_panic_2() {
 }
 
 #[test]
+fn regression_panic_3() {
+    let mut bytes: &[u8] = &[
+        246, 0, 134, 38, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 30, 132, 128, 0, 0, 80
+    ];
+    let _ = OuterStruct::pade_decode(&mut bytes, None);
+}
+
+#[test]
 fn bool_ordering_more_than_1byte() {
     #[derive(PadeEncode, PadeDecode, PartialEq, Eq, Debug)]
     struct OuterStruct {

--- a/pade-macro/tests/complex.rs
+++ b/pade-macro/tests/complex.rs
@@ -55,25 +55,55 @@ fn enums_have_correct_variant_bit_width() {
     );
 }
 
+fn roundtrip_decode_encode_decode<T: PadeEncode + PadeDecode + PartialEq + Eq + std::fmt::Debug>(
+    slice: &mut &[u8]
+) {
+    if let Ok(decoded) = T::pade_decode(slice, None) {
+        let bytes = decoded.pade_encode();
+        let decoded2 = T::pade_decode(&mut bytes.as_slice(), None).unwrap();
+        assert_eq!(decoded, decoded2);
+    }
+}
+
+#[test_fuzz::test_fuzz]
+fn roundtrip_outer_struct_a(slice: &mut &[u8]) {
+    roundtrip_decode_encode_decode::<OuterStructA>(slice);
+}
+
+#[test_fuzz::test_fuzz]
+fn roundtrip_outer_struct_b(slice: &mut &[u8]) {
+    roundtrip_decode_encode_decode::<OuterStructB>(slice);
+}
+
+#[test_fuzz::test_fuzz]
+fn roundtrip_user_order(slice: &mut &[u8]) {
+    roundtrip_decode_encode_decode::<UserOrder>(slice);
+}
+
+#[test_fuzz::test_fuzz]
+fn roundtrip_test_struct(slice: &mut &[u8]) {
+    roundtrip_decode_encode_decode::<TestStruct>(slice);
+}
+
 #[derive(PadeEncode, PadeDecode, PartialEq, Eq, Debug)]
-struct OuterStruct {
+struct OuterStructA {
     #[pade_width(3)]
     x:      i32,
-    enum1:  Cases,
+    enum1:  CasesA,
     list:   Vec<u128>,
     inside: Inside,
-    enum2:  Cases
+    enum2:  CasesA
 }
 
 #[derive(PadeEncode, PadeDecode, PartialEq, Eq, Debug)]
 struct Inside {
     number:  u128,
     another: u128,
-    enum1:   Cases
+    enum1:   CasesA
 }
 
 #[derive(PadeEncode, PadeDecode, PartialEq, Eq, Debug)]
-pub enum Cases {
+pub enum CasesA {
     Once { x: u128, y: u128 },
     Twice { a: u128, b: u128 },
     // memes
@@ -82,23 +112,21 @@ pub enum Cases {
 
 #[test]
 fn supports_struct_with_enum() {
-    let outer = OuterStruct {
+    let outer = OuterStructA {
         x:      34342,
-        enum1:  Cases::Twice { a: 10, b: 2000000 },
+        enum1:  CasesA::Twice { a: 10, b: 2000000 },
         list:   vec![1, 2, 3, 4023, 323424],
         inside: Inside {
-            enum1:   Cases::Thrice { a: 123, b: 423 },
+            enum1:   CasesA::Thrice { a: 123, b: 423 },
             number:  234093323,
             another: 234234
         },
-        enum2:  Cases::Thrice { a: 100, b: 2000000 }
+        enum2:  CasesA::Thrice { a: 100, b: 2000000 }
     };
 
     let encoded = outer.pade_encode();
     let mut slice = encoded.as_slice();
-    let decoded = OuterStruct::pade_decode(&mut slice, None).unwrap();
-
-    assert_eq!(outer, decoded);
+    let _ = roundtrip_outer_struct_a(&mut slice);
 }
 
 #[test]
@@ -113,13 +141,13 @@ fn regression_panic_1() {
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 123, 0, 0, 0, 0, 0, 0, 0, 255, 245, 0, 0, 0, 0,
         0, 1, 167, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
     ];
-    let _ = OuterStruct::pade_decode(&mut bytes, None);
+    let _ = OuterStructA::pade_decode(&mut bytes, None);
 }
 
 #[test]
 fn regression_panic_2() {
     let mut bytes: &[u8] = &[0];
-    let _ = OuterStruct::pade_decode(&mut bytes, None);
+    let _ = OuterStructA::pade_decode(&mut bytes, None);
 }
 
 #[test]
@@ -128,49 +156,47 @@ fn regression_panic_3() {
         246, 0, 134, 38, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 30, 132, 128, 0, 0, 80
     ];
-    let _ = OuterStruct::pade_decode(&mut bytes, None);
+    let _ = OuterStructA::pade_decode(&mut bytes, None);
+}
+
+#[derive(PadeEncode, PadeDecode, PartialEq, Eq, Debug)]
+struct OuterStructB {
+    a:  bool,
+    b:  bool,
+    c:  bool,
+    c1: bool,
+    c3: bool,
+    c2: bool,
+    d:  CasesB,
+    e:  CasesB
+}
+
+#[derive(PadeEncode, PadeDecode, PartialEq, Eq, Debug)]
+pub enum CasesB {
+    Once { x: u128, y: u128 },
+    Twice { a: u128, b: u128 },
+    // memes
+    Thrice { a: u128, b: u128 }
 }
 
 #[test]
 fn bool_ordering_more_than_1byte() {
-    #[derive(PadeEncode, PadeDecode, PartialEq, Eq, Debug)]
-    struct OuterStruct {
-        a:  bool,
-        b:  bool,
-        c:  bool,
-        c1: bool,
-        c3: bool,
-        c2: bool,
-        d:  Cases,
-        e:  Cases
-    }
-
-    #[derive(PadeEncode, PadeDecode, PartialEq, Eq, Debug)]
-    pub enum Cases {
-        Once { x: u128, y: u128 },
-        Twice { a: u128, b: u128 },
-        // memes
-        Thrice { a: u128, b: u128 }
-    }
-
-    let outer = OuterStruct {
+    let outer = OuterStructB {
         a:  true,
         b:  true,
         c:  true,
         c1: false,
         c2: false,
         c3: true,
-        d:  Cases::Twice { a: 0, b: 0 },
-        e:  Cases::Thrice { a: 0, b: 0 }
+        d:  CasesB::Twice { a: 0, b: 0 },
+        e:  CasesB::Thrice { a: 0, b: 0 }
     };
 
     let encoded = outer.pade_encode();
     let mut slice = encoded.as_slice();
     println!("{:08b}", slice[0]);
     println!("{:08b}", slice[1]);
-    let decoded = OuterStruct::pade_decode(&mut slice, None).unwrap();
-
-    assert_eq!(outer, decoded);
+    let _ = roundtrip_outer_struct_b(&mut slice);
 }
 
 #[test]
@@ -233,54 +259,51 @@ fn bool_ordering_lower() {
     assert_eq!(outer, decoded);
 }
 
-#[test]
-fn option_struct() {
-    #[derive(Debug, PadeEncode, PadeDecode, PartialEq, Eq)]
-    struct TestStruct {
-        pub number:     u32,
-        pub option:     Option<u128>,
-        pub number_two: u32,
-        pub bool:       bool
-    }
-
-    let s = TestStruct { number: 100, option: Some(95), number_two: 200, bool: true };
-    let bytes = s.pade_encode();
-    let mut slice = bytes.as_slice();
-    let decoded = TestStruct::pade_decode(&mut slice, None).unwrap();
-
-    assert_eq!(s, decoded);
+#[derive(Debug, PadeEncode, PadeDecode, PartialEq, Eq)]
+struct TestStruct {
+    pub number:     u32,
+    pub option:     Option<u128>,
+    pub number_two: u32,
+    pub bool:       bool
 }
 
 #[test]
+fn option_struct() {
+    let s = TestStruct { number: 100, option: Some(95), number_two: 200, bool: true };
+    let bytes = s.pade_encode();
+    let mut slice = bytes.as_slice();
+    let _ = roundtrip_test_struct(&mut slice);
+}
+
+#[derive(Debug, PadeEncode, PadeDecode, PartialEq, Eq)]
+pub enum OrderQuantities {
+    Exact { quantity: u128 },
+    Partial { min_quantity_in: u128, max_quantity_in: u128, filled_quantity: u128 }
+}
+
+#[derive(Debug, PadeEncode, PadeDecode, PartialEq, Eq)]
+enum Signature {
+    TypeOne,
+    TypeTwo
+}
+#[derive(Debug, PadeEncode, PadeDecode, PartialEq, Eq)]
+struct UserOrder {
+    pub ref_id:               u32,
+    pub use_internal:         bool,
+    pub pair_index:           u16,
+    pub min_price:            alloy::primitives::U256,
+    pub recipient:            Option<alloy::primitives::Address>,
+    pub hook_data:            Option<alloy::primitives::Bytes>,
+    pub zero_for_one:         bool,
+    pub standing_validation:  Option<u8>,
+    pub order_quantities:     OrderQuantities,
+    pub max_extra_fee_asset0: u128,
+    pub extra_fee_asset0:     u128,
+    pub exact_in:             bool,
+    pub signature:            Signature
+}
+#[test]
 fn super_specific_dave_test() {
-    #[derive(Debug, PadeEncode, PadeDecode, PartialEq, Eq)]
-    pub enum OrderQuantities {
-        Exact { quantity: u128 },
-        Partial { min_quantity_in: u128, max_quantity_in: u128, filled_quantity: u128 }
-    }
-
-    #[derive(Debug, PadeEncode, PadeDecode, PartialEq, Eq)]
-    enum Signature {
-        TypeOne,
-        TypeTwo
-    }
-    #[derive(Debug, PadeEncode, PadeDecode, PartialEq, Eq)]
-    struct UserOrder {
-        pub ref_id:               u32,
-        pub use_internal:         bool,
-        pub pair_index:           u16,
-        pub min_price:            alloy::primitives::U256,
-        pub recipient:            Option<alloy::primitives::Address>,
-        pub hook_data:            Option<alloy::primitives::Bytes>,
-        pub zero_for_one:         bool,
-        pub standing_validation:  Option<u8>,
-        pub order_quantities:     OrderQuantities,
-        pub max_extra_fee_asset0: u128,
-        pub extra_fee_asset0:     u128,
-        pub exact_in:             bool,
-        pub signature:            Signature
-    }
-
     let item = UserOrder {
         ref_id:               25,
         use_internal:         false,
@@ -302,7 +325,5 @@ fn super_specific_dave_test() {
     };
     let bytes = item.pade_encode();
     let mut slice = bytes.as_slice();
-    let decoded = UserOrder::pade_decode(&mut slice, None).unwrap();
-
-    assert_eq!(item, decoded);
+    let _ = roundtrip_user_order(&mut slice);
 }


### PR DESCRIPTION
This adds a roundtrip fuzzing harness that uses inputs from the unit tests as a seed corpus. Also, it passes raw bytes to decode as opposed to T as that is more likely to find crashes in the decoded.

`cargo test-fuzz` will run all the harnesses in round robin

To see all harnesses:
`cargo test-fuzz --list`
```
....
        [
            "roundtrip_outer_struct_a",
            "roundtrip_outer_struct_b",
            "roundtrip_test_struct",
            "roundtrip_user_order",
        ],
```
Run a specific one:
`cargo test-fuzz roundtrip_outer_struct_a`

replaces https://github.com/SorellaLabs/pade/pull/3

